### PR TITLE
[Tech Debt] lsoria/Refactorizar checkeo de led_port y extender coverage

### DIFF
--- a/src/leds.c
+++ b/src/leds.c
@@ -51,12 +51,12 @@ static uint16_t * led_port = NULL;
 
 int leds_init(uint16_t * port) {
     led_port = port;
-    *led_port = 0x00;
+    leds_turn_off_all();
     return 0;
 }
 
 void leds_deinit(void) {
-    *led_port = 0x00;
+    leds_turn_off_all();
     led_port = NULL;
 }
 

--- a/src/leds.c
+++ b/src/leds.c
@@ -83,14 +83,14 @@ int leds_get_status_single(uint16_t led) {
 int leds_turn_on_all(void) {
     CHECK_LED_PORT(led_port);
 
-    *led_port = 0xFF;
+    *led_port = 0xFFFF;
     return 0;
 }
 
 int leds_turn_off_all(void) {
     CHECK_LED_PORT(led_port);
 
-    *led_port = 0x00;
+    *led_port = 0x0000;
     return 0;
 }
 

--- a/src/leds.c
+++ b/src/leds.c
@@ -32,10 +32,16 @@ SPDX-License-Identifier: MIT
 
 #define LED_TO_BIT(led) (1 << led - 1)
 
+// Macro para retornar en caso de que led_port sea NULL
+#define CHECK_LED_PORT(port)                                                                       \
+    if (!led_port) {                                                                               \
+        return -1;                                                                                 \
+    }
+
 /* === Private data type declarations ========================================================== */
 /* === Private variable declarations =========================================================== */
 
-static uint16_t * led_port;
+static uint16_t * led_port = NULL;
 
 /* === Private function declarations =========================================================== */
 /* === Public variable definitions ============================================================= */
@@ -55,55 +61,43 @@ void leds_deinit(void) {
 }
 
 int leds_turn_on_single(uint16_t led) {
-    if (led_port) {
-        *led_port |= LED_TO_BIT(led);
-        return 0;
-    } else {
-        return -1;
-    }
+    CHECK_LED_PORT(led_port);
+
+    *led_port |= LED_TO_BIT(led);
+    return 0;
 }
 
 int leds_turn_off_single(uint16_t led) {
-    if (led_port) {
-        *led_port &= ~LED_TO_BIT(led);
-        return 0;
-    } else {
-        return -1;
-    }
+    CHECK_LED_PORT(led_port);
+
+    *led_port &= ~LED_TO_BIT(led);
+    return 0;
 }
 
 int leds_get_status_single(uint16_t led) {
-    if (led_port) {
-        return (*led_port & LED_TO_BIT(led)) != 0;
-    } else {
-        return -1;
-    }
+    CHECK_LED_PORT(led_port);
+
+    return (*led_port & LED_TO_BIT(led)) != 0;
 }
 
 int leds_turn_on_all(void) {
-    if (led_port) {
-        *led_port = 0xFF;
-        return 0;
-    } else {
-        return -1;
-    }
+    CHECK_LED_PORT(led_port);
+
+    *led_port = 0xFF;
+    return 0;
 }
 
 int leds_turn_off_all(void) {
-    if (led_port) {
-        *led_port = 0x00;
-        return 0;
-    } else {
-        return -1;
-    }
+    CHECK_LED_PORT(led_port);
+
+    *led_port = 0x00;
+    return 0;
 }
 
 int leds_get_status_all(void) {
-    if (led_port) {
-        return *led_port;
-    } else {
-        return -1;
-    }
+    CHECK_LED_PORT(led_port);
+
+    return *led_port;
 }
 
 /* === End of documentation ==================================================================== */

--- a/test/test_leds.c
+++ b/test/test_leds.c
@@ -33,7 +33,7 @@ SPDX-License-Identifier: MIT
 /* === Private data type declarations ========================================================== */
 /* === Private variable declarations =========================================================== */
 
-static uint16_t leds_port = 0xFF;
+static uint16_t leds_port = 0xFFFF;
 
 /* === Private function declarations =========================================================== */
 /* === Public variable definitions ============================================================= */
@@ -48,10 +48,10 @@ void setUp(void) {
 /// @brief Al iniciar el controlador todos los bits de los LEDs deben quedar en cero,
 ///  sin importar el estado anterior.
 void test_initial_state(void) {
-    uint16_t leds_port = 0xFF;
+    uint16_t leds_port = 0xFFFF;
 
-    TEST_ASSERT_EQUAL_INT(0x00, leds_init(&leds_port));
-    TEST_ASSERT_EQUAL_UINT16(0x00, leds_port);
+    TEST_ASSERT_EQUAL_INT(0x0000, leds_init(&leds_port));
+    TEST_ASSERT_EQUAL_UINT16(0x0000, leds_port);
 }
 
 /// @brief Con todos los LEDs apagados prender el LED3, y verificar que el bit 3 está en alto
@@ -59,7 +59,7 @@ void test_initial_state(void) {
 void test_single_led_on(void) {
     static const int LED = 3;
 
-    TEST_ASSERT_EQUAL_INT(0x00, leds_turn_on_single(LED));
+    TEST_ASSERT_EQUAL_INT(0x0000, leds_turn_on_single(LED));
     TEST_ASSERT_BIT_HIGH(LED - 1, leds_port);
     TEST_ASSERT_BITS_LOW(~(1 << (LED - 1)), leds_port);
 }
@@ -71,8 +71,8 @@ void test_single_led_off(void) {
 
     leds_turn_on_single(LED);
 
-    TEST_ASSERT_EQUAL_INT(0x00, leds_turn_off_single(LED));
-    TEST_ASSERT_EQUAL_UINT16(0x00, leds_port);
+    TEST_ASSERT_EQUAL_INT(0x0000, leds_turn_off_single(LED));
+    TEST_ASSERT_EQUAL_UINT16(0x0000, leds_port);
 }
 
 /// @brief Prender el LED5 dos veces, prender el LED7 una vez, apagar el LED5 una vez y apagar el
@@ -101,20 +101,20 @@ void test_single_led_get_status_on(void) {
     TEST_ASSERT_EQUAL_INT(1, leds_get_status_single(LED));
 }
 
-/// @brief Prender todos los LEDs y verificar que al consultar el estado del puerto sea 0xFF
+/// @brief Prender todos los LEDs y verificar que al consultar el estado del puerto sea 0xFFFF
 void test_all_leds_turn_on(void) {
 
     TEST_ASSERT_EQUAL_INT(0, leds_turn_on_all());
-    TEST_ASSERT_EQUAL_UINT16(0xFF, leds_get_status_all());
+    TEST_ASSERT_EQUAL_UINT16(0xFFFF, leds_get_status_all());
 }
 
 /// @brief Apagar todos los LEDs (prendidos previamente) y verificar que al consultar el estado del
-/// puerto sea 0x00
+/// puerto sea 0x0000
 void test_all_leds_turn_off(void) {
 
     leds_turn_on_all();
     leds_turn_off_all();
-    TEST_ASSERT_EQUAL_UINT16(0x00, leds_get_status_all());
+    TEST_ASSERT_EQUAL_UINT16(0x0000, leds_get_status_all());
 }
 
 /// @brief Deinicializar el puerto de los LEDs, y prender todos los LEDs.
@@ -124,7 +124,7 @@ void test_uninitialized_led_port(void) {
     leds_deinit();
 
     TEST_ASSERT_EQUAL_INT(-1, leds_turn_on_all());
-    TEST_ASSERT_EQUAL_UINT16(0x00, leds_port);
+    TEST_ASSERT_EQUAL_UINT16(0x0000, leds_port);
 }
 
 /// @brief Deinicializar el puerto de los LEDs, y consultar el estado del LED3.

--- a/test/test_leds.c
+++ b/test/test_leds.c
@@ -120,21 +120,34 @@ void test_all_leds_turn_off(void) {
 /// @brief Deinicializar el puerto de los LEDs, y prender todos los LEDs.
 /// El programa no debería sufrir una excepción y la función debe retornar -1.
 /// Por otro lado, el valor de `leds_port` deberá continuar en cero.
+/// Repetir lo mismo para todas las funciones de seteo: `leds_turn_off_all()`,
+/// `leds_turn_on_single()` y `leds_turn_off_single()`
 void test_uninitialized_led_port(void) {
+    static const int LED = 15;
+
     leds_deinit();
 
     TEST_ASSERT_EQUAL_INT(-1, leds_turn_on_all());
     TEST_ASSERT_EQUAL_UINT16(0x0000, leds_port);
+
+    TEST_ASSERT_EQUAL_INT(-1, leds_turn_off_all());
+
+    TEST_ASSERT_EQUAL_INT(-1, leds_turn_on_single(LED));
+
+    TEST_ASSERT_EQUAL_INT(-1, leds_turn_off_single(LED));
 }
 
 /// @brief Deinicializar el puerto de los LEDs, y consultar el estado del LED3.
 /// El programa no debería sufrir una excepción y la función `leds_get_status_single()` debe
 /// retornar -1.
-void test_uninitialized_led_port_get_single_value(void) {
+/// Repetir lo mismo llamando a `leds_get_status_all()`
+void test_uninitialized_led_port_get_status(void) {
     static const int LED = 3;
     leds_deinit();
 
     TEST_ASSERT_EQUAL_INT(-1, leds_get_status_single(LED));
+
+    TEST_ASSERT_EQUAL_INT(-1, leds_get_status_all());
 }
 
 /* === End of documentation ==================================================================== */


### PR DESCRIPTION
# Descripción

Aplicadas correcciones del TP2 en base a las observaciones marcadas [aquí](https://github.com/lmsoria/cese-tsse-tp2/issues) :

1. Evitar bloques repetidos que chequean que led_port no sea `NULL`. Para ello se creó la siguiente macro:

```
#define CHECK_LED_PORT(port) 
    if (!led_port) {
        return -1; 
    }
```

De esta forma, se puede chequear la nulidad de led_port al comienzo de cada función de la API.

2.  Cada vez que se ejecute `*leds_port = 0x0000;`, llamar directamente a `leds_turn_off_all()` para mantener claridad.

3. Extender coverage de los tests. Hay varias funciones en las que no se prueba su retorno -1 cuando se deinicializa el puerto.

## Testing hecho

Todas las pruebas unitarias han pasado, así como los chequeos de `pre-commit`:

```
$ ceedling clobber gcov:all utils:gcov

Clobbering all generated files...
(For large projects, this task may take a long time to complete)



Test 'test_leds.c'
------------------
Generating runner for test_leds.c...
Compiling test_leds_runner.c...
Compiling test_leds.c...
Compiling unity.c...
Compiling leds.c with coverage...
Compiling cmock.c...
Linking test_leds.out...
Running test_leds.out...
Creating gcov results report(s) in 'build/artifacts/gcov'... Done in 0.153 seconds.

--------------------------
GCOV: OVERALL TEST SUMMARY
--------------------------
TESTED:  9
PASSED:  9
FAILED:  0
IGNORED: 0


---------------------------
GCOV: CODE COVERAGE SUMMARY
---------------------------
leds.c Lines executed:100.00% of 30
leds.c Branches executed:100.00% of 12
leds.c Taken at least once:100.00% of 12
leds.c Calls executed:100.00% of 2
leds.c Lines executed:100.00% of 30

Could not find coverage results for src/main.c
```