### PR TITLE
lsoria/Agregar macros para codigos de error

### DIFF
--- a/inc/leds.h
+++ b/inc/leds.h
@@ -48,7 +48,7 @@ extern "C" {
 
 /// @brief Inicializa el puerto de LEDs, con todos ellos apagados.
 /// @param port puerto a inicializar.
-/// @return 0 en caso de éxito.
+/// @return LED_ERROR_OK en caso de éxito.
 int leds_init(uint16_t * port);
 
 /// @brief Deinicializa el puerto de LEDs previamente inicializado, dejándolo NULL
@@ -56,29 +56,35 @@ void leds_deinit(void);
 
 /// @brief Encender el LED deseado
 /// @param led LED a encender.
-/// @return 0 en caso de éxito, o -1 si el puerto no se encuentra inicializado.
+/// @return LED_ERROR_OK en caso de éxito, o LED_ERROR_UNINITIALIZED_PORT si el puerto no se
+/// encuentra inicializado.
 int leds_turn_on_single(uint16_t led);
 
 /// @brief Apagar el LED deseado
 /// @param led LED a apagar.
-/// @return 0 en caso de éxito, o -1 si el puerto no se encuentra inicializado.
+/// @return LED_ERROR_OK en caso de éxito, o LED_ERROR_UNINITIALIZED_PORT si el puerto no se
+/// encuentra inicializado.
 int leds_turn_off_single(uint16_t led);
 
 /// @brief Consultar el estado del LED deseado
 /// @param led LED a consultar.
-/// @return 1 si el LED está prendido, 0 si está apagado o -1 si el puerto no está inicializado.
+/// @return 1 si el LED está prendido, 0 si está apagado o LED_ERROR_UNINITIALIZED_PORT si el puerto
+/// no está inicializado.
 int leds_get_status_single(uint16_t led);
 
 /// @brief Prender todos los LEDs del puerto.
-/// @return 0 en caso de éxito, o -1 si el puerto no se encuentra inicializado.
+/// @return LED_ERROR_OK en caso de éxito, o LED_ERROR_UNINITIALIZED_PORT si el puerto no se
+/// encuentra inicializado.
 int leds_turn_on_all(void);
 
 /// @brief Apagar todos los LEDs del puerto.
-/// @return 0 en caso de éxito, o -1 si el puerto no se encuentra inicializado.
+/// @return 0 en caso de éxito, o LED_ERROR_UNINITIALIZED_PORT si el puerto no se encuentra
+/// inicializado.
 int leds_turn_off_all(void);
 
 /// @brief Consultar el estado de toda la máscara de LEDs del puerto.
-/// @return Máscara del puerto, o -1 si el puerto no se encuentra inicializado.
+/// @return Máscara del puerto, o LED_ERROR_UNINITIALIZED_PORT si el puerto no se encuentra
+/// inicializado.
 int leds_get_status_all(void);
 
 /* === End of documentation ==================================================================== */

--- a/inc/leds.h
+++ b/inc/leds.h
@@ -36,6 +36,12 @@ extern "C" {
 #endif
 
 /* === Public macros definitions =============================================================== */
+
+/// Indica que no hubo errores por parte de la API.
+#define LED_ERROR_OK (0)
+/// Indica que hubo un error al no encontrarse el puerto inicializado
+#define LED_ERROR_UNINITIALIZED_PORT (-1)
+
 /* === Public data type declarations =========================================================== */
 /* === Public variable declarations ============================================================ */
 /* === Public function declarations ============================================================ */

--- a/src/leds.c
+++ b/src/leds.c
@@ -35,7 +35,7 @@ SPDX-License-Identifier: MIT
 // Macro para retornar en caso de que led_port sea NULL
 #define CHECK_LED_PORT(port)                                                                       \
     if (!led_port) {                                                                               \
-        return -1;                                                                                 \
+        return LED_ERROR_UNINITIALIZED_PORT;                                                       \
     }
 
 /* === Private data type declarations ========================================================== */
@@ -52,7 +52,7 @@ static uint16_t * led_port = NULL;
 int leds_init(uint16_t * port) {
     led_port = port;
     leds_turn_off_all();
-    return 0;
+    return LED_ERROR_OK;
 }
 
 void leds_deinit(void) {
@@ -64,14 +64,14 @@ int leds_turn_on_single(uint16_t led) {
     CHECK_LED_PORT(led_port);
 
     *led_port |= LED_TO_BIT(led);
-    return 0;
+    return LED_ERROR_OK;
 }
 
 int leds_turn_off_single(uint16_t led) {
     CHECK_LED_PORT(led_port);
 
     *led_port &= ~LED_TO_BIT(led);
-    return 0;
+    return LED_ERROR_OK;
 }
 
 int leds_get_status_single(uint16_t led) {
@@ -84,14 +84,14 @@ int leds_turn_on_all(void) {
     CHECK_LED_PORT(led_port);
 
     *led_port = 0xFFFF;
-    return 0;
+    return LED_ERROR_OK;
 }
 
 int leds_turn_off_all(void) {
     CHECK_LED_PORT(led_port);
 
     *led_port = 0x0000;
-    return 0;
+    return LED_ERROR_OK;
 }
 
 int leds_get_status_all(void) {

--- a/test/test_leds.c
+++ b/test/test_leds.c
@@ -97,14 +97,14 @@ void test_multiple_leds_on_and_off(void) {
 void test_single_led_get_status_on(void) {
     static const int LED = 3;
 
-    TEST_ASSERT_EQUAL_INT(0, leds_turn_on_single(LED));
+    TEST_ASSERT_EQUAL_INT(LED_ERROR_OK, leds_turn_on_single(LED));
     TEST_ASSERT_EQUAL_INT(1, leds_get_status_single(LED));
 }
 
 /// @test Prender todos los LEDs y verificar que al consultar el estado del puerto sea 0xFFFF
 void test_all_leds_turn_on(void) {
 
-    TEST_ASSERT_EQUAL_INT(0, leds_turn_on_all());
+    TEST_ASSERT_EQUAL_INT(LED_ERROR_OK, leds_turn_on_all());
     TEST_ASSERT_EQUAL_UINT16(0xFFFF, leds_get_status_all());
 }
 
@@ -118,8 +118,8 @@ void test_all_leds_turn_off(void) {
 }
 
 /// @test Deinicializar el puerto de los LEDs, y prender todos los LEDs.
-/// El programa no debería sufrir una excepción y la función debe retornar -1.
-/// Por otro lado, el valor de `leds_port` deberá continuar en cero.
+/// El programa no debería sufrir una excepción y la función debe retornar
+/// LED_ERROR_UNINITIALIZED_PORT. Por otro lado, el valor de `leds_port` deberá continuar en cero.
 /// Repetir lo mismo para todas las funciones de seteo: `leds_turn_off_all()`,
 /// `leds_turn_on_single()` y `leds_turn_off_single()`
 void test_uninitialized_led_port(void) {
@@ -127,27 +127,27 @@ void test_uninitialized_led_port(void) {
 
     leds_deinit();
 
-    TEST_ASSERT_EQUAL_INT(-1, leds_turn_on_all());
+    TEST_ASSERT_EQUAL_INT(LED_ERROR_UNINITIALIZED_PORT, leds_turn_on_all());
     TEST_ASSERT_EQUAL_UINT16(0x0000, leds_port);
 
-    TEST_ASSERT_EQUAL_INT(-1, leds_turn_off_all());
+    TEST_ASSERT_EQUAL_INT(LED_ERROR_UNINITIALIZED_PORT, leds_turn_off_all());
 
-    TEST_ASSERT_EQUAL_INT(-1, leds_turn_on_single(LED));
+    TEST_ASSERT_EQUAL_INT(LED_ERROR_UNINITIALIZED_PORT, leds_turn_on_single(LED));
 
-    TEST_ASSERT_EQUAL_INT(-1, leds_turn_off_single(LED));
+    TEST_ASSERT_EQUAL_INT(LED_ERROR_UNINITIALIZED_PORT, leds_turn_off_single(LED));
 }
 
 /// @test Deinicializar el puerto de los LEDs, y consultar el estado del LED3.
 /// El programa no debería sufrir una excepción y la función `leds_get_status_single()` debe
-/// retornar -1.
+/// retornar LED_ERROR_UNINITIALIZED_PORT.
 /// Repetir lo mismo llamando a `leds_get_status_all()`
 void test_uninitialized_led_port_get_status(void) {
     static const int LED = 3;
     leds_deinit();
 
-    TEST_ASSERT_EQUAL_INT(-1, leds_get_status_single(LED));
+    TEST_ASSERT_EQUAL_INT(LED_ERROR_UNINITIALIZED_PORT, leds_get_status_single(LED));
 
-    TEST_ASSERT_EQUAL_INT(-1, leds_get_status_all());
+    TEST_ASSERT_EQUAL_INT(LED_ERROR_UNINITIALIZED_PORT, leds_get_status_all());
 }
 
 /* === End of documentation ==================================================================== */


### PR DESCRIPTION
# Brief
Agregados los siguientes `#define`s:
```
/// Indica que no hubo errores por parte de la API.
#define LED_ERROR_OK (0)
/// Indica que hubo un error al no encontrarse el puerto inicializado
#define LED_ERROR_UNINITIALIZED_PORT (-1)
```

De esta forma, se evita hardcodear valores mágicos para el retorno de errores de la API